### PR TITLE
New demo script for a simple task run

### DIFF
--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-##
-## Fixme: This works with the default chains config which is
-## to use 'tekton' for storage and 'tekton' for the format. I can't
-## make the verify-blob work with the storage configured to use 'oci'
-## but I'll keep this script to help figure it out.
-##
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Use a specific taskrun if provided, otherwise use the latest
@@ -27,6 +20,16 @@ else
   QUIET=
 fi
 
+title() {
+  $ECHO
+  $ECHO "🔗 ---- $* ----"
+}
+
+pause() {
+  [[ -n $QUIET ]] && return
+  read -p "Hit enter continue"
+}
+
 # Helper for jsonpath
 get-jsonpath() {
   kubectl get $TASKRUN_NAME -o jsonpath={.$1}
@@ -37,10 +40,55 @@ get-chainsval() {
   get-jsonpath metadata.annotations.chains\\.tekton\\.dev/$1
 }
 
-# Fetch signature and payload
+# Helper for reading a task result
+get-taskresult() {
+  kubectl get $TASKRUN_NAME \
+    -o jsonpath="{.status.taskResults[?(@.name == \"$1\")].value}"
+}
+
+# Fetch task run signature and payload
 TASKRUN_UID=$( get-jsonpath metadata.uid )
 SIGNATURE=$( get-chainsval signature-taskrun-$TASKRUN_UID )
 PAYLOAD=$( get-chainsval payload-taskrun-$TASKRUN_UID | base64 --decode )
+
+IMAGE_DIGEST=$( get-taskresult IMAGE_DIGEST )
+if [[ -n $IMAGE_DIGEST ]]; then
+  SHORT_IMAGE_DIGEST=$( get-taskresult IMAGE_DIGEST | cut -d: -f2 | head -c 12 )
+  IMAGE_SIGNATURE=$( get-chainsval signature-$SHORT_IMAGE_DIGEST )
+  IMAGE_PAYLOAD=$( get-chainsval payload-$SHORT_IMAGE_DIGEST | base64 --decode)
+
+  # Todo: Do something with these, or create a separate
+  # check-taskrun-image.sh to verify image signatures
+  #echo $IMAGE_DIGEST
+fi
+
+# Try to detect and then handle different formats
+# (It seems like it would be better if the format was available
+# explicitly but afaict it is not.)
+
+# If the signature is 96 chars then we might be using tekton format
+if [[ ${#SIGNATURE} == 96 ]]; then
+  title "Assuming tekton format"
+  # The signature is just the signature, continue
+
+else
+  title "Assuming in-toto format"
+
+  # The signature value is actually encoded json with a payload and
+  # signature list inside it
+  SIG_DATA=$( echo $SIGNATURE | base64 --decode )
+  SIGNATURE=$( echo $SIG_DATA | jq -r '.signatures[0].sig' )
+
+  # No idea why the same payload can be found in both places...
+  OTHER_PAYLOAD=$( echo $SIG_DATA | jq -r .payload | base64 --decode )
+
+  if [[ "$PAYLOAD" != "$OTHER_PAYLOAD" ]]; then
+    # Seems like we'll never get here
+    echo "The two payloads are unexpectedly different!"
+    exit 1
+  fi
+
+fi
 
 # Cosign wants files on disk afaict
 SIG_FILE=$( mktemp )
@@ -58,11 +106,6 @@ if [[ -z $SIG_KEY ]]; then
   #SIG_KEY=$SCRIPTDIR/../../cosign.pub
 fi
 
-title() {
-  $ECHO
-  $ECHO "🔗 ---- $* ----"
-}
-
 # Show details about this taskrun
 title Taskrun name
 $ECHO $TASKRUN_NAME
@@ -70,17 +113,30 @@ $ECHO $TASKRUN_NAME
 title Signature
 $ECHO $SIGNATURE
 
+pause
+
 title Payload
 #[[ -z $QUIET ]] && echo "$PAYLOAD" | jq
 [[ -z $QUIET ]] && echo "$PAYLOAD" | yq e -P -
 
+pause
+
 # Keep going if the verify fails
 set +e
 
+## Fixme: This only works with artifacts.taskrun.format set to 'tekton'.
+## I've never been able to use cosign verify-blob to verify a task's
+## payload and signature using the 'in-toto' format and I don't know why.
+
 # Now use cosign to verify the signed payload
 title Verification
+[[ -z $QUIET ]] && set -x
 cosign verify-blob --key $SIG_KEY --signature $SIG_FILE $PAYLOAD_FILE
 COSIGN_EXIT_CODE=$?
+set +x
+
+title "For debugging"
+$ECHO "env EDITOR=view oc edit $TASKRUN_NAME"
 
 # Clean up
 rm $SIG_FILE $PAYLOAD_FILE

--- a/hack/chains/nice-logs.sh
+++ b/hack/chains/nice-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# For viewing tekton chains logs
+#
+kubectl logs \
+  -f --log-flush-frequency=1s --since=0 --tail=0 -l app=tekton-chains-controller -n tekton-chains |
+    grep --line-buffered -v -E 'Reconcile succeeded|is still running' |
+      jq -r '"\(.ts) \(.level) \(.msg)"'
+      #jq '{ts: .ts, level: .level, msg: .msg}'
+      #jq

--- a/hack/chains/simple-demo.sh
+++ b/hack/chains/simple-demo.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Based on https://github.com/tektoncd/chains/blob/main/docs/tutorials/getting-started-tutorial.md
+#
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -ue
+
+title "Suggested config for this demo:"
+$SCRIPTDIR/config.sh simple --dry-run
+
+title "Current config:"
+$SCRIPTDIR/config.sh
+
+title "Run a simple task and watch its logs"
+kubectl create -f \
+  https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
+tkn tr logs --follow --last
+
+#??
+#?? The task produces a fake manifest json file with a digest that is
+#?? visible to chains if oci storage is enabled, and I don't understand
+#?? how or why.
+#??
+
+title "Wait a few seconds for chains finalizers to complete"
+sleep 10
+
+# Use this to show details about the taskrun and cosign verify it
+$SCRIPTDIR/check-taskrun.sh


### PR DESCRIPTION
The demo is less interesting than the existing kaniko build since
the task run does not create an image, but I think it's useful to be
able to exercise it in a script to demonstrate how we think it
works.

Also it's useful for troubleshooting and hacking, e.g. we can switch
the format to in-toto easily, or enable rekor and run the same
script to test things.

Also:
- Add some extra handling of the signature field in check-taskrun.sh
  to help debug and troubleshoot the in-toto format.
- Add a script to make it easier to read chains controller logs