### PR TITLE
New demo script for a simple task run

### DIFF
--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-##
-## Fixme: This works with the default chains config which is
-## to use 'tekton' for storage and 'tekton' for the format. I can't
-## make the verify-blob work with the storage configured to use 'oci'
-## but I'll keep this script to help figure it out.
-##
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Use a specific taskrun if provided, otherwise use the latest
@@ -27,6 +20,16 @@ else
   QUIET=
 fi
 
+title() {
+  $ECHO
+  $ECHO "🔗 ---- $* ----"
+}
+
+pause() {
+  [[ -n $QUIET ]] && return
+  read -p "Hit enter continue"
+}
+
 # Helper for jsonpath
 get-jsonpath() {
   kubectl get $TASKRUN_NAME -o jsonpath={.$1}
@@ -37,10 +40,55 @@ get-chainsval() {
   get-jsonpath metadata.annotations.chains\\.tekton\\.dev/$1
 }
 
-# Fetch signature and payload
+# Helper for reading a task result
+get-taskresult() {
+  kubectl get $TASKRUN_NAME \
+    -o jsonpath="{.status.taskResults[?(@.name == \"$1\")].value}"
+}
+
+# Fetch task run signature and payload
 TASKRUN_UID=$( get-jsonpath metadata.uid )
 SIGNATURE=$( get-chainsval signature-taskrun-$TASKRUN_UID )
 PAYLOAD=$( get-chainsval payload-taskrun-$TASKRUN_UID | base64 --decode )
+
+IMAGE_DIGEST=$( get-taskresult IMAGE_DIGEST )
+if [[ -n $IMAGE_DIGEST ]]; then
+  SHORT_IMAGE_DIGEST=$( get-taskresult IMAGE_DIGEST | cut -d: -f2 | head -c 12 )
+  IMAGE_SIGNATURE=$( get-chainsval signature-$SHORT_IMAGE_DIGEST )
+  IMAGE_PAYLOAD=$( get-chainsval payload-$SHORT_IMAGE_DIGEST | base64 --decode)
+
+  # Todo: Do something with these, or create a separate
+  # check-taskrun-image.sh to verify image signatures
+  #echo $IMAGE_DIGEST
+fi
+
+# Try to detect and then handle different formats
+# (It seems like it would be better if the format was available
+# explicitly but afaict it is not.)
+
+# If the signature is 96 chars then we might be using tekton format
+if [[ ${#SIGNATURE} == 96 ]]; then
+  title "Assuming tekton format"
+  # The signature is just the signature, continue
+
+else
+  title "Assuming in-toto format"
+
+  # The signature value is actually encoded json with a payload and
+  # signature list inside it
+  SIG_DATA=$( echo $SIGNATURE | base64 --decode )
+  SIGNATURE=$( echo $SIG_DATA | jq -r '.signatures[0].sig' )
+
+  # No idea why the same payload can be found in both places...
+  OTHER_PAYLOAD=$( echo $SIG_DATA | jq -r .payload | base64 --decode )
+
+  if [[ "$PAYLOAD" != "$OTHER_PAYLOAD" ]]; then
+    # Seems like we'll never get here
+    echo "The two payloads are unexpectedly different!"
+    exit 1
+  fi
+
+fi
 
 # Cosign wants files on disk afaict
 SIG_FILE=$( mktemp )
@@ -58,11 +106,6 @@ if [[ -z $SIG_KEY ]]; then
   #SIG_KEY=$SCRIPTDIR/../../cosign.pub
 fi
 
-title() {
-  $ECHO
-  $ECHO "🔗 ---- $* ----"
-}
-
 # Show details about this taskrun
 title Taskrun name
 $ECHO $TASKRUN_NAME
@@ -70,17 +113,30 @@ $ECHO $TASKRUN_NAME
 title Signature
 $ECHO $SIGNATURE
 
+pause
+
 title Payload
 #[[ -z $QUIET ]] && echo "$PAYLOAD" | jq
 [[ -z $QUIET ]] && echo "$PAYLOAD" | yq e -P -
 
+pause
+
 # Keep going if the verify fails
 set +e
 
+## Fixme: This only works with artifacts.taskrun.format set to 'tekton'.
+## I've never been able to use cosign verify-blob to verify a task's
+## payload and signature using the 'in-toto' format and I don't know why.
+
 # Now use cosign to verify the signed payload
 title Verification
+[[ -z $QUIET ]] && set -x
 cosign verify-blob --key $SIG_KEY --signature $SIG_FILE $PAYLOAD_FILE
 COSIGN_EXIT_CODE=$?
+set +x
+
+title "For debugging"
+$ECHO "env EDITOR=view oc edit $TASKRUN_NAME"
 
 # Clean up
 rm $SIG_FILE $PAYLOAD_FILE

--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -55,6 +55,17 @@ case "$1" in
 
     ;;
 
+  quay )
+    # Currently quay.io doesn't support oci storage for attestations
+    $0 '{
+      "artifacts.taskrun.format": "in-toto",
+      "artifacts.taskrun.storage": "tekton",
+      "artifacts.oci.storage": "oci",
+      "transparency.enabled": "true"
+      }' $2
+
+    ;;
+
   rekor-on )
     # (Needs to be a string not a boolean FYI)
     $0 'transparency.enabled: "true"' $2

--- a/hack/chains/kaniko-demo-build.sh
+++ b/hack/chains/kaniko-demo-build.sh
@@ -6,6 +6,8 @@ set -ue
 
 echo "To watch the chains controller logs:"
 echo "  kubectl logs -f -l app=tekton-chains-controller -n tekton-chains"
+echo "or:"
+echo "  hack/chains/nice-logs.sh"
 pause
 
 title "Set project"

--- a/hack/chains/kaniko-demo-build.sh
+++ b/hack/chains/kaniko-demo-build.sh
@@ -5,9 +5,7 @@ source $SCRIPTDIR/_helpers.sh
 set -ue
 
 echo "To watch the chains controller logs:"
-echo "  kubectl logs -f -l app=tekton-chains-controller -n tekton-chains"
-echo "or:"
-echo "  hack/chains/nice-logs.sh"
+echo "  kubectl logs -f -l app=tekton-chains-controller -n tekton-chains | sed G"
 pause
 
 title "Set project"

--- a/hack/chains/nice-logs.sh
+++ b/hack/chains/nice-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# For viewing tekton chains logs
+#
+kubectl logs \
+  -f --log-flush-frequency=1s --since=0 --tail=0 -l app=tekton-chains-controller -n tekton-chains |
+    grep --line-buffered -v -E 'Reconcile succeeded|is still running' |
+      jq -r '"\(.ts) \(.level) \(.msg)"'
+      #jq '{ts: .ts, level: .level, msg: .msg}'
+      #jq

--- a/hack/chains/pipeline-quay-demo.sh
+++ b/hack/chains/pipeline-quay-demo.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -e
+
+echo "To watch the chains controller logs:"
+echo "  kubectl logs -f -l app=tekton-chains-controller -n tekton-chains | sed G"
+echo "or:"
+echo "  hack/chains/nice-logs.sh"
+pause
+
+title "Set project"
+# It shouldn't matter, but let's make sure it works without being in
+# tekton-chains project or whatever
+oc project default
+
+if [[ -z "$QUAY_SECRET_NAME" ]]; then
+  echo "Please set environment variable QUAY_SECRET_NAME and try again!"
+  echo "For example: export QUAY_SECRET_NAME=sbaird-chains-demo-pull-secret"
+  exit 1
+fi
+
+if [[ -z "$QUAY_IMAGE" ]]; then
+  echo "Please set environment variable QUAY_IMAGE and try again!"
+  echo "For example: export QUAY_IMAGE=quay.io/sbaird/chains-demo"
+  exit 1
+fi
+
+if ! kubectl get secret/$QUAY_SECRET_NAME -o name; then
+  echo "Can't find $QUAY_SECRET_NAME!" &&
+  echo "Please ensure it exists and try again!" &&
+  echo "For example: kubectl apply -f sbaird-chains-demo-secret.yml"
+  exit 1
+fi
+
+# Ensure we have the cluster task and pipeline ready for this demo
+kubectl apply -f $SCRIPTDIR/pipeline-quay-demo.yaml
+
+# Run the pipeline
+tkn pipeline start \
+  --param IMAGE="$QUAY_IMAGE" \
+  --param PUSH_SECRET_NAME="$QUAY_SECRET_NAME" \
+  --showlog \
+  -w name=source,pvc,claimName="ci-builds" \
+  chains-demo-pipeline

--- a/hack/chains/pipeline-quay-demo.yaml
+++ b/hack/chains/pipeline-quay-demo.yaml
@@ -1,0 +1,198 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ci-builds
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
+    tekton.dev/displayName: s2i nodejs
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: s2i, nodejs, workspace
+  labels:
+    app.kubernetes.io/version: "0.1"
+    operator.tekton.dev/provider-type: redhat
+  name: s2i-nodejs-chains
+spec:
+  description: s2i-nodejs task clones a Git repository and builds and pushes a container
+    image using S2I and a nodejs builder image.
+  params:
+  - default: 14-ubi8
+    description: The tag of nodejs imagestream for nodejs version
+    name: VERSION
+    type: string
+  - default: .
+    description: The location of the path to run s2i from.
+    name: PATH_CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - description: Location of the repo where image has to be pushed
+    name: IMAGE
+    type: string
+  - description: Push secret name
+    name: PUSH_SECRET_NAME
+    type: string
+  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+    description: The location of the buildah builder image.
+    name: BUILDER_IMAGE
+    type: string
+  - description: Git CHAINS URL
+    name: CHAINS-GIT_URL
+    type: string
+  - description: Git CHAINS Commit
+    name: CHAINS-GIT_COMMIT
+    type: string
+  results:
+  - description: Digest of the image just built.
+    name: IMAGE_DIGEST
+  - description: URL of the image just built.
+    name: IMAGE_URL
+  steps:
+  - command:
+    - s2i
+    - build
+    - $(params.PATH_CONTEXT)
+    - image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION)
+    - --as-dockerfile
+    - /gen-source/Dockerfile.gen
+    env:
+    - name: HOME
+      value: /tekton/home
+    image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:e518e05a730ae066e371a4bd36a5af9cedc8686fd04bd59648d20ea0a486d7e5
+    name: generate
+    resources: {}
+    volumeMounts:
+    - mountPath: /gen-source
+      name: gen-source
+    workingDir: $(workspaces.source.path)
+  - command:
+    - buildah
+    - bud
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --layers
+    - -f
+    - /gen-source/Dockerfile.gen
+    - -t
+    - $(params.IMAGE)
+    - .
+    image: $(params.BUILDER_IMAGE)
+    name: build
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /gen-source
+      name: gen-source
+    workingDir: /gen-source
+  - command:
+    - buildah
+    - push
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --digestfile=$(workspaces.source.path)/image-digest
+    - $(params.IMAGE)
+    - docker://$(params.IMAGE)
+    image: $(params.BUILDER_IMAGE)
+    env:
+      - name: REGISTRY_AUTH_FILE
+        value: /etc/quay-secret/config.json
+    name: push
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - name: quay-secret
+      mountPath: /etc/quay-secret
+    workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: digest-to-results
+    resources: {}
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  - name: write-url
+    image: bash
+    script: echo "$(params.IMAGE)" | tee /tekton/results/IMAGE_URL
+  - name: write-git-commit
+    image: bash
+    script: echo $(params.CHAINS-GIT_COMMIT) | tee /tekton/results/CHAINS-GIT_COMMIT
+  - name: write-git-url
+    image: bash
+    script: echo $(params.CHAINS-GIT_URL) | tee /tekton/results/CHAINS-GIT_URL
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: gen-source
+  - name: quay-secret
+    secret:
+      secretName: "$(params.PUSH_SECRET_NAME)"
+      items:
+      - key: .dockerconfigjson
+        path: config.json
+  workspaces:
+  - mountPath: /workspace/source
+    name: source
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: chains-demo-pipeline
+spec:
+  params:
+  - name: IMAGE
+    type: string
+    description: 'Image path on registry'
+  - name: PUSH_SECRET_NAME
+    type: string
+    description: 'Registry secret name for push'
+  workspaces:
+  - name: source
+  tasks:
+  - name: git-clone
+    params:
+    - name: url
+      value: 'https://github.com/caugello/single-nodejs-app'
+    - name: deleteExisting
+      value: 'true'
+    - name: verbose
+      value: 'true'
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+      - name: output
+        workspace: source
+  - name: build
+    taskRef:
+      kind: ClusterTask
+      name: s2i-nodejs-chains
+    params:
+    - name: IMAGE
+      value: "$(params.IMAGE)"
+    - name: PUSH_SECRET_NAME
+      value: "$(params.PUSH_SECRET_NAME)"
+    - name: TLSVERIFY
+      value: 'false'
+    - name: CHAINS-GIT_COMMIT
+      value: "$(tasks.git-clone.results.commit)"
+    - name: CHAINS-GIT_URL
+      value: "$(tasks.git-clone.results.url)"
+    workspaces:
+    - name: source
+      workspace: source
+    runAfter:
+    - git-clone

--- a/hack/chains/simple-demo.sh
+++ b/hack/chains/simple-demo.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Based on https://github.com/tektoncd/chains/blob/main/docs/tutorials/getting-started-tutorial.md
+#
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -ue
+
+title "Suggested config for this demo:"
+$SCRIPTDIR/config.sh simple --dry-run
+
+title "Current config:"
+$SCRIPTDIR/config.sh
+
+title "Run a simple task and watch its logs"
+kubectl create -f \
+  https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
+tkn tr logs --follow --last
+
+#??
+#?? The task produces a fake manifest json file with a digest that is
+#?? visible to chains if oci storage is enabled, and I don't understand
+#?? how or why.
+#??
+
+title "Wait a few seconds for chains finalizers to complete"
+sleep 10
+
+# Use this to show details about the taskrun and cosign verify it
+$SCRIPTDIR/check-taskrun.sh


### PR DESCRIPTION
The demo is less interesting than the existing kaniko build since
the task run does not create an image, but I think it's useful to be
able to exercise it in a script to demonstrate how we think it
works.

Also it's useful for troubleshooting and hacking, e.g. we can switch
the format to in-toto easily, or enable rekor and run the same
script to test things.

Also:
- Add some extra handling of the signature field in check-taskrun.sh
  to help debug and troubleshoot the in-toto format.
- Add a script to make it easier to read chains controller logs